### PR TITLE
🚧 Add archive notice to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 [//]: # "DO NOT CHANGE THIS FILE WITHOUT CHANGING .github/scripts/readme-template.md"
 
+# ⚠️ Archived
+
+This repository has been archived since [`actionlint` now has a its own `pre-commit` hooks](https://github.com/rhysd/actionlint/blob/main/.pre-commit-hooks.yaml).
+
 # actionlint mirror
 
 Mirror of `actionlint` for pre-commit.


### PR DESCRIPTION
Since `actionlint` now has a `pre-commit` hook this project isn't needed anymore it can be archived.